### PR TITLE
3人目以降の変換対象のデフォルト値を可能な限り十干にする

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -77,7 +77,15 @@ export default {
       this.generatedContract = this.formattedContract;
     },
     addParty() {
-      const newPartyLabel = `名前${this.parties.length + 3}`;
+      const heavenlyStems = ["丙", "丁", "戊", "己", "庚", "辛", "壬", "癸"];
+      let newPartyLabel = "";
+
+      if (this.parties.length < heavenlyStems.length) {
+        newPartyLabel = heavenlyStems[this.parties.length];
+      } else {
+        newPartyLabel = `名前${this.parties.length + 3}`;
+      }
+
       this.parties.push({ name: "", label: newPartyLabel });
     },
     removeParty(index) {


### PR DESCRIPTION
変換対象の文字列は十干 ( https://ja.wikipedia.org/wiki/%E5%8D%81%E5%B9%B2 ) に基づいて振られるケースが多いのではないかと思うので、3人目以降の変換対象のデフォルト値を可能な限り十干にするようにしました。