### PR TITLE
変換後の文章が空の場合は右ペインを表示しない

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -55,13 +55,19 @@ export default {
       });
 
       let replacedContract = this.contractText;
+      let replacedContractText = this.contractText;
 
       this.parties.forEach(({ name, label }) => {
         const className = `party${label.slice(-1)}`;
         const color = '#4caf50';
-        replacedContract = replacedContract.replace(new RegExp(label, 'g'), `<span class="${className}" style="color: ${color};">${name}</span>`);
+        const pattern = new RegExp(label, 'g');
+        replacedContract = replacedContract.replace(pattern, `<span class="${className}" style="color: ${color};">${name}</span>`);
+        replacedContractText = replacedContractText.replace(pattern, name);
       });
 
+      if (replacedContractText === "") {
+        return "";
+      }
 
       return replacedContract;
     },


### PR DESCRIPTION
甲乙の名前が空で、契約書の文章が甲乙のみの場合、実際には変換後の文字列は空なので、そのような場合は右ペインを表示しないようにします。