### PR TITLE
出力後の文書を読みやすくする

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -207,7 +207,7 @@ export default {
 }
 
 .result-container {
-  text-align: center;
+  text-align: left;
 }
 
 .generated-text-box {


### PR DESCRIPTION
現行では生成後の文章が中央ぞろえで出力されますが、契約書を読むのに中央配置だと少し大変だと思うので左揃えにしてみました。
![タイトルなし](https://github.com/CAT5NEKO/kouOtsu/assets/111590457/7f597395-0dc1-43e2-98f3-131ccde1c7f9)

![2](https://github.com/CAT5NEKO/kouOtsu/assets/111590457/bb010d38-b631-47e3-b053-0ca5a01fe60a)

好みの問題もありますからどちらにしようか悩んでおります。

よく見てみるとPDF.jsは文書の余白を改行と認識しているみたいで不自然な部分で改行してしまってるので、ここをどうするか...といったところです。